### PR TITLE
Tests fixed

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -60,7 +60,7 @@ def differ(value, origin):
             except KeyError:
                 raise AssertionError('''{0} not match original: {1};
 Key: {2}, item: {3}'''.format(value, origin, key, item))
-            return
+        return
 
     if isinstance(origin, basestring):
         assert value == origin, '{0} not match original: {1}.'.format(value, origin)
@@ -103,7 +103,7 @@ def number_test():
     >>> differ(lua.decode('''{      \
         ID = 0x74fa4cae,            \
         Version = 0x07c2,           \
-        Manfacturer = 0x21544948    \
+        Manufacturer = 0x21544948    \
     }'''), {                        \
         'ID': 0x74fa4cae,           \
         'Version': 0x07c2,          \


### PR DESCRIPTION
`differ` were checking only one key when comaring `dict`s and then immediately return (which means success). That's why typo in "Manufactorer" didn't caused tests to fail.