### PR TITLE
Python 3 support, testing using `unittest`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,5 @@ setup(
     license='https://github.com/SirAnthony/slpp/blob/master/LICENSE',
     keywords=['lua'],
     py_modules=['slpp'],
+    install_requires=['six'],
 )

--- a/slpp.py
+++ b/slpp.py
@@ -1,5 +1,8 @@
 import re
 import sys
+from numbers import Number
+
+import six
 
 ERRORS = {
     'unexp_end_string': u'Unexpected end of string while parsing Lua string.',
@@ -28,9 +31,9 @@ class SLPP(object):
         self.tab = '\t'
 
     def decode(self, text):
-        if not text or not isinstance(text, basestring):
+        if not text or not isinstance(text, six.string_types):
             return
-        #FIXME: only short comments removed
+        # FIXME: only short comments removed
         reg = re.compile('--.*$', re.M)
         text = reg.sub('', text, 0)
         self.text = text
@@ -48,35 +51,38 @@ class SLPP(object):
         s = ''
         tab = self.tab
         newline = self.newline
-        tp = type(obj)
+
         if isinstance(obj, str):
             s += '"%s"' % obj.replace(r'"', r'\"')
-        if isinstance(obj, unicode):
+        elif six.PY2 and isinstance(obj, unicode):
             s += '"%s"' % obj.encode('utf-8').replace(r'"', r'\"')
-        elif tp in [int, float, long, complex]:
-            s += str(obj)
-        elif tp is bool:
+        elif six.PY3 and isinstance(obj, bytes):
+            s += '"{}"'.format(''.join(r'\x{:02x}'.format(c) for c in obj))
+        elif isinstance(obj, bool):
             s += str(obj).lower()
         elif obj is None:
             s += 'nil'
-        elif tp in [list, tuple, dict]:
+        elif isinstance(obj, Number):
+            s += str(obj)
+        elif isinstance(obj, (list, tuple, dict)):
             self.depth += 1
-            if len(obj) == 0 or ( tp is not dict and len(filter(
-                    lambda x:  type(x) in (int,  float,  long) \
-                    or (isinstance(x, basestring) and len(x) < 10),  obj
-                )) == len(obj) ):
+            if len(obj) == 0 or (not isinstance(obj, dict) and len([
+                    x for x in obj
+                    if isinstance(x, Number) or (isinstance(x, six.string_types) and len(x) < 10)
+               ]) == len(obj)):
                 newline = tab = ''
             dp = tab * self.depth
             s += "%s{%s" % (tab * (self.depth - 2), newline)
-            if tp is dict:
+            if isinstance(obj, dict):
                 contents = []
-                for k, v in obj.iteritems():
-                    if type(k) is int:
+                all_keys_int = all(isinstance(k, int) for k in obj.keys())
+                for k, v in obj.items():
+                    if all_keys_int:
                         contents.append(self.__encode(v))
                     else:
                         contents.append(dp + '%s = %s' % (k, self.__encode(v)))
                 s += (',%s' % newline).join(contents)
-                
+
             else:
                 s += (',%s' % newline).join(
                     [dp + self.__encode(el) for el in obj])
@@ -129,7 +135,7 @@ class SLPP(object):
                     if self.ch != end:
                         s += '\\'
                 s += self.ch
-        print ERRORS['unexp_end_string']
+        raise ParseError(ERRORS['unexp_end_string'])
 
     def object(self):
         o = {}
@@ -142,7 +148,7 @@ class SLPP(object):
         if self.ch and self.ch == '}':
             self.depth -= 1
             self.next_chr()
-            return o #Exit here
+            return o  # Exit here
         else:
             while self.ch:
                 self.white()
@@ -154,13 +160,13 @@ class SLPP(object):
                     self.depth -= 1
                     self.next_chr()
                     if k is not None:
-                       o[idx] = k
-                    if not numeric_keys and len([ key for key in o if isinstance(key, (str, unicode, float,  bool,  tuple))]) == 0:
+                        o[idx] = k
+                    if not numeric_keys and len([key for key in o if isinstance(key, six.string_types + (float,  bool, tuple))]) == 0:
                         ar = []
                         for key in o:
-                           ar.insert(key, o[key])
+                            ar.insert(key, o[key])
                         o = ar
-                    return o #or here
+                    return o  # or here
                 else:
                     if self.ch == ',':
                         self.next_chr()
@@ -181,7 +187,7 @@ class SLPP(object):
                             o[idx] = k
                         idx += 1
                         k = None
-        print ERRORS['unexp_end_table'] #Bad exit here
+        raise ParseError(ERRORS['unexp_end_table'])  # Bad exit here
 
     words = {'true': True, 'false': False, 'nil': None}
     def word(self):
@@ -240,8 +246,7 @@ class SLPP(object):
 
     def hex(self):
         n = ''
-        while self.ch and \
-            (self.ch in 'ABCDEFabcdef' or self.ch.isdigit()):
+        while self.ch and (self.ch in 'ABCDEFabcdef' or self.ch.isdigit()):
             n += self.ch
             self.next_chr()
         return n

--- a/tests.py
+++ b/tests.py
@@ -1,55 +1,26 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from slpp import slpp as lua
+import unittest
+import six
+
+from slpp import slpp
 
 """
 Tests for slpp
 """
 
 
+# Utility functions
+
 def is_iterator(obj):
-    """
-    >>> assert is_iterator(list()) is True
-    >>> assert is_iterator(int) is False
-    """
-    if isinstance(obj, (list, tuple)):
-        return True
     try:
         iter(obj)
         return True
     except TypeError:
         return False
 
-
 def differ(value, origin):
-    """
-    Same:
-    >>> differ(1, 1)
-    >>> differ([2, 3], [2, 3])
-    >>> differ({'1': 3, '4': '6'}, {'4': '6', '1': 3})
-    >>> differ('4', '4')
-
-    Different:
-    >>> differ(1, 2)
-    Traceback (most recent call last):
-       ...
-    AssertionError: 1 not match original: 2.
-    >>> differ([2, 3], [3, 2])
-    Traceback (most recent call last):
-       ...
-    AssertionError: 2 not match original: 3.
-    >>> differ({'6': 4, '3': '1'}, {'4': '6', '1': 3})
-    Traceback (most recent call last):
-       ...
-    AssertionError: {'3': '1', '6': 4} not match original: {'1': 3, '4': '6'};
-    Key: 1, item: 3
-    >>> differ('4', 'no')
-    Traceback (most recent call last):
-       ...
-    AssertionError: 4 not match original: no.
-    """
-
     if type(value) is not type(origin):
         raise AssertionError('Types does not match: {0}, {1}'.format(type(value), type(origin)))
 
@@ -58,11 +29,11 @@ def differ(value, origin):
             try:
                 differ(value[key], item)
             except KeyError:
-                raise AssertionError('''{0} not match original: {1};
-Key: {2}, item: {3}'''.format(value, origin, key, item))
+                raise AssertionError('''{0} not match original: {1}; Key: {2}, item: {3}'''.format(
+                    value, origin, key, item))
         return
 
-    if isinstance(origin, basestring):
+    if isinstance(origin, six.string_types):
         assert value == origin, '{0} not match original: {1}.'.format(value, origin)
         return
 
@@ -73,110 +44,108 @@ Key: {2}, item: {3}'''.format(value, origin, key, item))
             except IndexError:
                 raise AssertionError(
                     '{0} not match original: {1}. Item {2} not found'.format(
-                        response, origin, origin[i]))
-            except Exception, e:
-                raise e
+                        value, origin, origin[i]))
         return
 
     assert value == origin, '{0} not match original: {1}.'.format(value, origin)
 
 
+class TestUtilityFunctions(unittest.TestCase):
+
+    def test_is_iterator(self):
+        self.assertTrue(is_iterator(list()))
+        self.assertFalse(is_iterator(int))
+
+    def test_differ(self):
+        # Same:
+        differ(1, 1)
+        differ([2, 3], [2, 3])
+        differ({'1': 3, '4': '6'}, {'4': '6', '1': 3})
+        differ('4', '4')
+
+        # Different:
+        self.assertRaises(AssertionError, differ, 1, 2)
+        self.assertRaises(AssertionError, differ, [2, 3], [3, 2])
+        self.assertRaises(AssertionError, differ, {'6': 4, '3': '1'}, {'4': '6', '1': 3})
+        self.assertRaises(AssertionError, differ, '4', 'no')
 
 
-def number_test():
-    """
-    Integer and float:
-    >>> assert lua.decode('3') == 3
-    >>> assert lua.decode('4.1') == 4.1
+class TestSLPP(unittest.TestCase):
 
-    Negative float:
-    >>> assert lua.decode('-0.45') == -0.45
+    def test_numbers(self):
+        # Integer and float:
+        self.assertEqual(slpp.decode('3'), 3)
+        self.assertEqual(slpp.decode('4.1'), 4.1)
+        self.assertEqual(slpp.encode(3), '3')
+        self.assertEqual(slpp.encode(4.1), '4.1')
 
-    Scientific:
-    >>> assert lua.decode('3e-7') == 3e-7
-    >>> assert lua.decode('-3.23e+17') == -3.23e+17
+        # Negative float:
+        self.assertEqual(slpp.decode('-0.45'), -0.45)
+        self.assertEqual(slpp.encode(-0.45), '-0.45')
 
-    Hex:
-    >>> assert lua.decode('0x3a') == 0x3a
+        # Scientific:
+        self.assertEqual(slpp.decode('3e-7'), 3e-7)
+        self.assertEqual(slpp.decode('-3.23e+17'), -3.23e+17)
+        self.assertEqual(slpp.encode(3e-7), '3e-07')
+        self.assertEqual(slpp.encode(-3.23e+17), '-3.23e+17')
 
-    #4
-    >>> differ(lua.decode('''{      \
-        ID = 0x74fa4cae,            \
-        Version = 0x07c2,           \
-        Manufacturer = 0x21544948    \
-    }'''), {                        \
-        'ID': 0x74fa4cae,           \
-        'Version': 0x07c2,          \
-        'Manufacturer': 0x21544948  \
-    })
-    """
-    pass
+        # Hex:
+        self.assertEqual(slpp.decode('0x3a'), 0x3a)
 
+        differ(slpp.decode('''{
+            ID = 0x74fa4cae,
+            Version = 0x07c2,
+            Manufacturer = 0x21544948
+        }'''), {
+            'ID': 0x74fa4cae,
+            'Version': 0x07c2,
+            'Manufacturer': 0x21544948
+        })
 
-def test_bool():
-    """
-    >>> assert lua.decode('false') == False
-    >>> assert lua.decode('true') == True
+    def test_bool(self):
+        self.assertEqual(slpp.encode(True), 'true')
+        self.assertEqual(slpp.encode(False), 'false')
 
-    >>> assert lua.encode(False) == 'false'
-    >>> assert lua.encode(True) == 'true'
-    """
-    pass
+        self.assertEqual(slpp.decode('true'), True)
+        self.assertEqual(slpp.decode('false'), False)
 
+    def test_nil(self):
+        self.assertEqual(slpp.encode(None), 'nil')
+        self.assertEqual(slpp.decode('nil'), None)
 
-def test_nil():
-    """
-    >>> assert lua.decode('nil') == None
-    >>> assert lua.encode(None) == 'nil'
-    """
-    pass
+    def test_table(self):
+        # Bracketed string key:
+        self.assertEqual(slpp.decode('{[10] = 1}'), {10: 1})
 
+        # Void table:
+        self.assertEqual(slpp.decode('{nil}'), [])
 
-def table_test():
-    """
-    Bracketed string key:
-    >>> assert lua.decode('{[10] = 1}') == {10: 1}
+        # Values-only table:
+        self.assertEqual(slpp.decode('{"10"}'), ["10"])
 
-    Void table:
-    >>> assert lua.decode('{nil}') == []
+        # Last zero
+        self.assertEqual(slpp.decode('{0, 1, 0}'), [0, 1, 0])
 
-    Values-only table:
-    >>> assert lua.decode('{"10"}') == ["10"]
+    def test_string(self):
+        # Escape test:
+        self.assertEqual(slpp.decode(r"'test\'s string'"), "test's string")
 
-    Last zero
-    >>> assert lua.decode('{0, 1, 0}') == [0,1,0]
-    """
-    pass
+        # Add escaping on encode:
+        self.assertEqual(slpp.encode({'a': 'func("call()");'}), '{\n\ta = "func(\\"call()\\");"\n}')
 
-def string_test():
-    r"""
-    Escape test:
-    >>> assert lua.decode(r"'test\'s string'") == "test's string"
+    def test_basic(self):
+        # No data loss:
+        data = '{ array = { 65, 23, 5 }, dict = { string = "value", array = { 3, 6, 4}, mixed = { 43, 54.3, false, string = "value", 9 } } }'
+        d = slpp.decode(data)
+        differ(d, slpp.decode(slpp.encode(d)))
 
-    Add escaping on encode:
-    >>> assert lua.encode({'a': 'func("call()");'}) == '{\n\ta = "func(\\"call()\\");"\n}'
-    """
-    pass
-
-def basic_test():
-    """
-    No data loss:
-
-    >>> data = '{ array = { 65, 23, 5 }, dict = { string = "value", array = { 3, 6, 4}, mixed = { 43, 54.3, false, string = "value", 9 } } }'
-    >>> d = lua.decode(data)
-    >>> differ(d, lua.decode(lua.encode(d)))
-    """
-    pass
-
-
-def unicode_test():
-    ur"""
-    >>> assert lua.encode(u'Привет') == '"\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"'
-    >>> assert lua.encode({'s': u'Привет'}) == '{\n\ts = "Привет"\n}'
-    """
-    pass
+    def test_unicode(self):
+        if six.PY2:
+            self.assertEqual(slpp.encode(u'Привет'), '"\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"')
+        if six.PY3:
+            self.assertEqual(slpp.encode(u'Привет'), '"Привет"')
+        self.assertEqual(slpp.encode({'s': u'Привет'}), '{\n\ts = "Привет"\n}')
 
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
+    unittest.main()


### PR DESCRIPTION
Python 3 support added. Tested at least on 3.4 and 3.5.

`encode()` returns `str`. It is so called "native strings": bytes-based `str` on Python 2 and unicode-based `str` on Python 3.

Test rewritten using `unittest` instead of `doctest` to make it possible to write different tests for Py2 and Py3.

`print "error"` replaced with `raise Error` in a couple of places.

If you'd prefer to not introduce external dependencies, I can remove `six` and include `six.PY2/3` and `six.string_types` to `slpp.py`.
