### PR TITLE
Fix for incorrect encoding of lua table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 #### SLPP
 SLPP is a simple lua-python data structures parser.
 
+Install:
+```python
+pip install git+https://github.com/Igneous01/slpp
+```
+
 Lua data check:
 
 ```lua

--- a/slpp.py
+++ b/slpp.py
@@ -84,8 +84,8 @@ class SLPP(object):
             dp = tab * self.depth
             s += "%s{%s" % (tab * (self.depth - 2), newline)
             if isinstance(obj, dict):
-                key = '[%s]' if all(isinstance(k, int) for k in obj.keys()) else '%s'
-                contents = [dp + (key + ' = %s') % (k, self.__encode(v)) for k, v in obj.items()]
+                key_list = ['[%s]' if isinstance(k, int) else '["%s"]' for k in obj.keys()]
+                contents = [dp + (key + ' = %s') % (k, self.__encode(v)) for (k, v), key in zip(obj.items(), key_list)]
                 s += (',%s' % newline).join(contents)
             else:
                 s += (',%s' % newline).join(


### PR DESCRIPTION
Fixed an issue where dictionary with mixed numbers and strings as keys was encoding incorrectly. Prior to this change encode would turn the following:

t = {
    [0] = 0,
    ["name"] = "john"
}

into

t = {
    0 = 0,
    name = "john"
}

which is not valid lua. This patch respects the way keys should be defined if they are numbers vs strings