### PR TITLE
Fix #23: Comments vs. -- in strings

### DIFF
--- a/slpp.py
+++ b/slpp.py
@@ -43,9 +43,6 @@ class SLPP(object):
     def decode(self, text):
         if not text or not isinstance(text, six.string_types):
             return
-        # FIXME: only short comments removed
-        reg = re.compile('--.*$', re.M)
-        text = reg.sub('', text, 0)
         self.text = text
         self.at, self.ch, self.depth = 0, '', 0
         self.len = len(text)
@@ -100,6 +97,18 @@ class SLPP(object):
                 self.next_chr()
             else:
                 break
+
+        self.skip_comments()
+
+    def skip_comments(self):
+        if self.ch == '-' and self.text[self.at] == '-':
+            # `--` is a comment, skip to next new line
+            while self.ch:
+                if re.match('\n', self.ch):
+                    self.white()
+                    break
+                else:
+                    self.next_chr()
 
     def next_chr(self):
         if self.at >= self.len:

--- a/tests.py
+++ b/tests.py
@@ -157,5 +157,14 @@ class TestSLPP(unittest.TestCase):
         t('{ [5] = 111, [4] = 52.1, 43, [3] = 54.3, false, 9 }')
         t('{ [1] = 1, [2] = "2", 3, 4, [5] = 5 }')
 
+    def test_comments(self):
+        lua = '-- starting comment\n{\n["multiline_string"] = "A multiline string where one of the lines starts with\n-- two dashes",\n-- middle comment\n["another_multiline_string"] = "A multiline string where one of the lines starts with\n-- two dashes\nfollowed by another line",\n["trailing_comment"] = "A string with" -- a trailing comment\n}\n-- ending comment'
+        dict = {
+            "multiline_string": "A multiline string where one of the lines starts with\n-- two dashes",
+            "another_multiline_string": "A multiline string where one of the lines starts with\n-- two dashes\nfollowed by another line",
+            "trailing_comment": "A string with"
+        }
+        self.assertEqual(slpp.decode(lua), dict)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I believe this fixes the parse error when a string contains `--` as described in #23. Also includes a test case.